### PR TITLE
GET /myParty API 구현 #11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,5 @@ gradle-app.setting
 
 # End of https://www.toptal.com/developers/gitignore/api/java,intellij+all,macos,windows,gradle
 .idea/codeStyles/codeStyleConfig.xml
+
+bin/

--- a/src/main/java/kr/flab/ottsharing/controller/MyPartyController.java
+++ b/src/main/java/kr/flab/ottsharing/controller/MyPartyController.java
@@ -1,0 +1,20 @@
+package kr.flab.ottsharing.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.flab.ottsharing.protocol.MyParty;
+import kr.flab.ottsharing.service.MyPartyService;
+
+@RestController
+public class MyPartyController {
+    @Autowired
+    private MyPartyService myPartyService;
+
+    @GetMapping("/myParty")
+    public MyParty viewMyParty(@CookieValue(name = "memberId", required = false) String userId) {
+        return myPartyService.getMyParty("유저2");
+    }
+}

--- a/src/main/java/kr/flab/ottsharing/entity/Party.java
+++ b/src/main/java/kr/flab/ottsharing/entity/Party.java
@@ -2,13 +2,7 @@ package kr.flab.ottsharing.entity;
 
 import java.time.LocalDateTime;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.OneToOne;
+import javax.persistence.*;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -24,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(name = "party")
 public class Party {
     @Id
     @Column(name = "party_id")

--- a/src/main/java/kr/flab/ottsharing/entity/PartyMember.java
+++ b/src/main/java/kr/flab/ottsharing/entity/PartyMember.java
@@ -3,15 +3,7 @@ package kr.flab.ottsharing.entity;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
+import javax.persistence.*;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -27,6 +19,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 @Entity
+@Table(name = "partyMember")
 public class PartyMember {
 
     @Id

--- a/src/main/java/kr/flab/ottsharing/entity/User.java
+++ b/src/main/java/kr/flab/ottsharing/entity/User.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Table;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.springframework.data.annotation.CreatedDate;
@@ -21,6 +22,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
+@Table(name = "user")
 public class User {
 
     @Id

--- a/src/main/java/kr/flab/ottsharing/protocol/MyParty.java
+++ b/src/main/java/kr/flab/ottsharing/protocol/MyParty.java
@@ -1,0 +1,31 @@
+package kr.flab.ottsharing.protocol;
+
+import java.util.List;
+
+import kr.flab.ottsharing.entity.User;
+import lombok.Getter;
+
+@Getter
+public class MyParty {
+    private Status status;
+    private User leader;
+    private List<PartyMember> partyMembers;
+    private String ottId;
+    private String ottPw;
+
+    public MyParty(Status status) {
+        this.status = status;
+        this.partyMembers = null;
+        this.ottId = null;
+        this.ottPw = null;
+    }
+
+    public MyParty(User leader, List<User> partyMembers, String ottId, String ottPw) {
+        this.status = Status.HAS_PARTY;
+        this.leader = leader;
+        this.ottId = ottId;
+        this.ottPw = ottPw;
+    }
+
+    public enum Status { NOT_LOGIN, HAS_NO_PARTY, WAITING_FOR_PARTY, HAS_PARTY }
+}

--- a/src/main/java/kr/flab/ottsharing/repository/PartyMemberRepository.java
+++ b/src/main/java/kr/flab/ottsharing/repository/PartyMemberRepository.java
@@ -1,17 +1,24 @@
 package kr.flab.ottsharing.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+import kr.flab.ottsharing.entity.Party;
 import kr.flab.ottsharing.entity.PartyMember;
 import kr.flab.ottsharing.entity.User;
 
+@Repository
 public interface PartyMemberRepository extends JpaRepository<PartyMember,Integer> {
 
-    List<PartyMember> findByUser(User user);
+    @Query("select pm.party from PartyMember pm where pm.user=:user")
+    Optional<Party> findPartyByUser(@Param("user") User user);
 
-
-
+    @Query("select pm.user from PartyMember pm where pm.party=:party")
+    List<User> findUsersByParty(@Param("party") Party party);
 
 }

--- a/src/main/java/kr/flab/ottsharing/repository/PartyWaitingRepository.java
+++ b/src/main/java/kr/flab/ottsharing/repository/PartyWaitingRepository.java
@@ -1,5 +1,6 @@
 package kr.flab.ottsharing.repository;
 
+import kr.flab.ottsharing.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,6 +10,8 @@ import kr.flab.ottsharing.entity.PartyWaiting;
 public interface PartyWaitingRepository extends JpaRepository<PartyWaiting, Integer> {
     @Override
     <S extends PartyWaiting> S save(S entity);
+
+    boolean existsByUser(User user);
 
     Iterable<PartyWaiting> findTop3ByOrderByCreatedTimeAsc();
 

--- a/src/main/java/kr/flab/ottsharing/service/MyPartyService.java
+++ b/src/main/java/kr/flab/ottsharing/service/MyPartyService.java
@@ -1,0 +1,42 @@
+package kr.flab.ottsharing.service;
+
+import kr.flab.ottsharing.entity.Party;
+import kr.flab.ottsharing.entity.User;
+import kr.flab.ottsharing.repository.PartyMemberRepository;
+import kr.flab.ottsharing.repository.PartyWaitingRepository;
+import kr.flab.ottsharing.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import kr.flab.ottsharing.protocol.MyParty;
+
+import java.util.Optional;
+
+@Service
+public class MyPartyService {
+    @Autowired
+    private PartyMemberRepository memberRepo;
+    @Autowired
+    private UserRepository userRepo;
+    @Autowired
+    private PartyWaitingRepository waitRepo;
+
+    public MyParty getMyParty(String userId) {
+        if (userId == null || userId.isEmpty()) {
+            return new MyParty(MyParty.Status.NOT_LOGIN);
+        }
+
+        User user = userRepo.getById(userId);
+        Optional<Party> optionalParty = memberRepo.findPartyByUser(user);
+        if (optionalParty.isPresent()) {
+            Party party = optionalParty.get();
+            return new MyParty(party.getLeader(), memberRepo.findUsersByParty(party), party.getOttId(), party.getOttPassword());
+        }
+
+        if (waitRepo.existsByUser(user)) {
+            return new MyParty(MyParty.Status.WAITING_FOR_PARTY);
+        }
+
+        return new MyParty(MyParty.Status.HAS_NO_PARTY);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,3 +7,7 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher # Spring boot 2.6버전 이후부터 발생하는 Swagger3.0.0 충돌 문제 해결하기 위한 설정
+  jpa:
+    hibernate:
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl

--- a/src/test/java/kr/flab/ottsharing/repository/PartyMemberTest.java
+++ b/src/test/java/kr/flab/ottsharing/repository/PartyMemberTest.java
@@ -14,10 +14,11 @@ import kr.flab.ottsharing.entity.Party;
 import kr.flab.ottsharing.entity.PartyMember;
 import kr.flab.ottsharing.entity.User;
 
+import java.util.List;
+
 @ExtendWith(SpringExtension.class)
 @DataJpaTest
 @TestPropertySource("classpath:application-test.yml")
-@Transactional
 public class PartyMemberTest {
 
     @Autowired
@@ -28,20 +29,30 @@ public class PartyMemberTest {
     private PartyRepository partyRepo;
 
     @Test
-    void 나의파티찾기_테스트(){
-
+    void 나의파티찾기_파티원목록조회_테스트(){
+        //given
         final User user1 = User.builder().userId("유저1").build();
-        final User savedUser = userRepo.save(user1);
-        final Party party = Party.builder().leader(savedUser).ottId("id").ottPassword("pass").build();
-        final Party myparty = partyRepo.save(party);
-        final PartyMember partyMember = PartyMember.builder().user(savedUser).party(myparty).build();
+        final User savedUser1 = userRepo.save(user1);
+        final User user2 = User.builder().userId("유저2").build();
+        final User savedUser2 = userRepo.save(user2);
+        final User user3 = User.builder().userId("유저3").build();
+        final User savedUser3 = userRepo.save(user3);
 
-        memberRepo.save(partyMember);
+        final Party party = Party.builder().leader(savedUser1).ottId("id").ottPassword("pass").build();
+        final Party savedParty = partyRepo.save(party);
 
-        Party result = memberRepo.findByUser(savedUser).get(0).getParty();
-        assertEquals("1",result.getPartyId());
+        //when
+        final PartyMember partyMember2 = PartyMember.builder().user(savedUser2).party(savedParty).build();
+        memberRepo.save(partyMember2);
+        final PartyMember partyMember3 = PartyMember.builder().user(savedUser3).party(savedParty).build();
+        memberRepo.save(partyMember3);
 
+        //then
+        assertEquals(savedParty, memberRepo.findPartyByUserId(savedUser2).get());
+
+        List<User> members = memberRepo.findUsersByParty(savedParty);
+        assertEquals(true, members.contains(savedUser2));
+        assertEquals(true, members.contains(savedUser3));
     }
-
 
 }


### PR DESCRIPTION
* 기본적으로 테이블 이름이 대문자로 되어있으면 언더스코어 형식(party_member)으로 변환해버려서 인식이 안됐음
  * 그래서 변환을 안하도록 application.yml에서 설정하고 User, Party, PartyMember 엔티티에서 수동으로 테이블이름을 지정해주었음
* PartyMemberRepository의 메소드로 myParty API를 구현할 수가 없었음. 그래서 findPartyByUser, findUserByParty라는 메소드를 추가하는 개량을 함
* PartyWaitingRepository에 대기자 목록에 이 유저가 있는지 알아내는 existsByUser가 있어야 하는데 요구사항에 없었음. 그래서 추가함
* MyParty 프로토콜, 서비스, 컨트롤러 구현
  * 로그인이 되어있다면 쿠키에 'memberId=아이디'가 있다는 전제하에 짰음

굉장한 스파게티 코드를 만든 것 같습니다..
아마 대부분 엎게 될거같아서 테스트 코드는 따로 짜지 않고 직접 실행 테스트만 했습니다