### PR TITLE
feat: User Entity&Repository 개선

### DIFF
--- a/src/main/java/kr/flab/ottsharing/entity/User.java
+++ b/src/main/java/kr/flab/ottsharing/entity/User.java
@@ -28,7 +28,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Column(name = "user_userid",unique = true)
+    @Column(name = "user_userid", unique = true)
     private String userId;
 
     @Column(name = "user_password")

--- a/src/main/java/kr/flab/ottsharing/entity/User.java
+++ b/src/main/java/kr/flab/ottsharing/entity/User.java
@@ -2,12 +2,10 @@ package kr.flab.ottsharing.entity;
 
 import java.time.LocalDateTime;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -27,10 +25,25 @@ public class User {
 
     @Id
     @Column(name = "user_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "user_userid",unique = true)
     private String userId;
 
+    @Column(name = "user_password")
+    private String userPassword;
+
+    @Column(unique = true)
+    private String email;
+
+    private Long money;
 
     @Column(name = "created_timestamp")
     @CreationTimestamp
     private LocalDateTime createdTime;
+
+    @Column(name = "updated_timestamp")
+    @UpdateTimestamp
+    private LocalDateTime updatedTime;
 }

--- a/src/main/java/kr/flab/ottsharing/repository/UserRepository.java
+++ b/src/main/java/kr/flab/ottsharing/repository/UserRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import kr.flab.ottsharing.entity.User;
 
-public interface UserRepository extends JpaRepository<User,Integer> {
+public interface UserRepository extends JpaRepository<User, Integer> {
 
     Optional<User> findByUserId(String userId);
 

--- a/src/main/java/kr/flab/ottsharing/repository/UserRepository.java
+++ b/src/main/java/kr/flab/ottsharing/repository/UserRepository.java
@@ -9,9 +9,9 @@ import kr.flab.ottsharing.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Integer> {
 
-    Optional<User> findByUserId(String userId);
+    boolean existsByUserId(String userId);
 
-    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
 
     User findOneByUserId(String userId);
 

--- a/src/main/java/kr/flab/ottsharing/repository/UserRepository.java
+++ b/src/main/java/kr/flab/ottsharing/repository/UserRepository.java
@@ -13,7 +13,7 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 
     boolean existsByEmail(String email);
 
-    User findOneByUserId(String userId);
+    User findByUserId(String userId);
 
     void deleteById(Integer id);
 }

--- a/src/main/java/kr/flab/ottsharing/repository/UserRepository.java
+++ b/src/main/java/kr/flab/ottsharing/repository/UserRepository.java
@@ -1,13 +1,19 @@
 package kr.flab.ottsharing.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import kr.flab.ottsharing.entity.User;
 
-public interface UserRepository extends JpaRepository<User,String> {
+public interface UserRepository extends JpaRepository<User,Integer> {
 
-    @Override
-    Optional<User> findById(String userId);
+    Optional<User> findByUserId(String userId);
+
+    Optional<User> findByEmail(String email);
+
+    User findOneByUserId(String userId);
+
+    void deleteById(Integer id);
 }

--- a/src/test/java/kr/flab/ottsharing/repository/UserRepositoryTest.java
+++ b/src/test/java/kr/flab/ottsharing/repository/UserRepositoryTest.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
@@ -28,9 +29,11 @@ public class UserRepositoryTest {
     @Autowired
     private UserRepository userRepository;
 
-    @Test
-    void 내용넣기_테스트(){
-        User user1 = User.builder()
+    User user1;
+
+    @BeforeEach
+    public void before(){
+        user1 = User.builder()
                 .userId("유저1")
                 .userPassword("1234")
                 .email("email1")
@@ -38,26 +41,23 @@ public class UserRepositoryTest {
                 .build();
 
         userRepository.save(user1);
+    }
+    @Test
+    void 가입_테스트(){
 
         User result = userRepository.findOneByUserId(user1.getUserId());
         assertEquals("유저1", result.getUserId());
         assertEquals("1234", result.getUserPassword());
         assertEquals("email1", result.getEmail());
+
    }
 
     @Test
     void 탈퇴_테스트() {
-        User user1 = User.builder()
-                .userId("유저1")
-                .userPassword("1234")
-                .email("email1")
-                .money(0l)
-                .build();
 
-        userRepository.save(user1);
         userRepository.deleteById(user1.getId());
-        Optional<User> result = userRepository.findByUserId(user1.getUserId());
-        assertEquals(false, result.isPresent());
+        boolean result = userRepository.existsByUserId(user1.getUserId());
+        assertEquals(false, result);
 
     }
 }

--- a/src/test/java/kr/flab/ottsharing/repository/UserRepositoryTest.java
+++ b/src/test/java/kr/flab/ottsharing/repository/UserRepositoryTest.java
@@ -1,36 +1,63 @@
 package kr.flab.ottsharing.repository;
 
 import java.util.List;
+import java.util.Optional;
 
+import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 import kr.flab.ottsharing.entity.User;
 
-@SpringBootTest
-@Transactional
-// @RunWith(SpringJUnit4ClassRunner.class)
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+@TestPropertySource("classpath:application-test.yml")
 public class UserRepositoryTest {
 
     @Autowired
     private UserRepository userRepository;
 
     @Test
-    void 내용넣기테스트(){
+    void 내용넣기_테스트(){
         User user1 = User.builder()
-            .userId("유저1")
-            .build();
+                .userId("유저1")
+                .userPassword("1234")
+                .email("email1")
+                .money(0l)
+                .build();
 
         userRepository.save(user1);
 
-        User result = userRepository.findById(user1.getUserId()).get();
-        Assertions.assertThat(user1).isEqualTo(result);
+        User result = userRepository.findOneByUserId(user1.getUserId());
+        assertEquals("유저1", result.getUserId());
+        assertEquals("1234", result.getUserPassword());
+        assertEquals("email1", result.getEmail());
    }
 
+    @Test
+    void 탈퇴_테스트() {
+        User user1 = User.builder()
+                .userId("유저1")
+                .userPassword("1234")
+                .email("email1")
+                .money(0l)
+                .build();
 
+        userRepository.save(user1);
+        userRepository.deleteById(user1.getId());
+        Optional<User> result = userRepository.findByUserId(user1.getUserId());
+        assertEquals(false, result.isPresent());
+
+    }
 }

--- a/src/test/java/kr/flab/ottsharing/repository/UserRepositoryTest.java
+++ b/src/test/java/kr/flab/ottsharing/repository/UserRepositoryTest.java
@@ -45,7 +45,7 @@ public class UserRepositoryTest {
     @Test
     void 가입_테스트(){
 
-        User result = userRepository.findOneByUserId(user1.getUserId());
+        User result = userRepository.findByUserId(user1.getUserId());
         assertEquals("유저1", result.getUserId());
         assertEquals("1234", result.getUserPassword());
         assertEquals("email1", result.getEmail());


### PR DESCRIPTION
* 확장된 UserDB 컬럼 추가
* UserRepository 추가 
* isExistsByUserId과 isExistsByEmail은 Optional을 쓰고자 isExist가 아닌 findby를 이용해 수행하도록함. Optional를 통해 값이 없을 수 있으니 주의하란 메시지로 전달하고자함.