### PR TITLE
PartyMember - Entity & Repository 개선 #32

### DIFF
--- a/src/main/java/kr/flab/ottsharing/entity/PartyMember.java
+++ b/src/main/java/kr/flab/ottsharing/entity/PartyMember.java
@@ -1,11 +1,11 @@
 package kr.flab.ottsharing.entity;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 import javax.persistence.*;
 
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import lombok.AllArgsConstructor;
@@ -19,13 +19,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 @Entity
-@Table(name = "partyMember")
+@Table(name = "party_member")
 public class PartyMember {
-
     @Id
-    @JoinColumn(name = "member_id")
+    @Column(name = "party_member_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer memberId;
+    private Integer partyMemberId;
 
     @OneToOne
     @JoinColumn(name = "user_id")
@@ -35,9 +34,19 @@ public class PartyMember {
     @JoinColumn(name = "party_id")
     private Party party;
 
+    @Column(name = "nickname")
+    private String nickname;
+
+    @Column(name = "is_leader")
+    private boolean isLeader;
+
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
     @Column(name = "created_timestamp")
     @CreationTimestamp
     private LocalDateTime createdTime;
 
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
+    @Column(name = "updated_timestamp")
+    @UpdateTimestamp
+    private LocalDateTime updatedTime;
 }

--- a/src/main/java/kr/flab/ottsharing/repository/PartyMemberRepository.java
+++ b/src/main/java/kr/flab/ottsharing/repository/PartyMemberRepository.java
@@ -4,8 +4,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import kr.flab.ottsharing.entity.Party;
@@ -14,11 +12,7 @@ import kr.flab.ottsharing.entity.User;
 
 @Repository
 public interface PartyMemberRepository extends JpaRepository<PartyMember,Integer> {
+    Optional<PartyMember> findOneByUser(User user);
 
-    @Query("select pm.party from PartyMember pm where pm.user=:user")
-    Optional<Party> findPartyByUser(@Param("user") User user);
-
-    @Query("select pm.user from PartyMember pm where pm.party=:party")
-    List<User> findUsersByParty(@Param("party") Party party);
-
+    List<PartyMember> findByParty(Party party);
 }

--- a/src/test/java/kr/flab/ottsharing/repository/PartyMemberRepositoryTest.java
+++ b/src/test/java/kr/flab/ottsharing/repository/PartyMemberRepositoryTest.java
@@ -1,16 +1,24 @@
 package kr.flab.ottsharing.repository;
 
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import kr.flab.ottsharing.entity.Party;
+import kr.flab.ottsharing.entity.PartyMember;
+import kr.flab.ottsharing.entity.User;
+
 @ExtendWith(SpringExtension.class)
 @DataJpaTest
 @TestPropertySource("classpath:application-test.yml")
 public class PartyMemberRepositoryTest {
-
     @Autowired
     private PartyMemberRepository memberRepo;
     @Autowired
@@ -18,10 +26,8 @@ public class PartyMemberRepositoryTest {
     @Autowired
     private PartyRepository partyRepo;
 
-    // Party Entity 구조 변경으로 인해 동작이 안되는 코드
-    /*
     @Test
-    void 나의파티찾기_파티원목록조회_테스트(){
+    void User로_PartyMember_행_찾기_테스트(){
         //given
         final User user1 = User.builder().userId("유저1").build();
         final User savedUser1 = userRepo.save(user1);
@@ -30,23 +36,46 @@ public class PartyMemberRepositoryTest {
         final User user3 = User.builder().userId("유저3").build();
         final User savedUser3 = userRepo.save(user3);
 
-        final Party party = Party.builder().leader(savedUser1).ottId("id").ottPassword("pass").build();
+        final Party party = Party.builder().ottId("id").ottPassword("pass").build();
         final Party savedParty = partyRepo.save(party);
 
         //when
+        final PartyMember partyMember1 = PartyMember.builder().user(savedUser1).isLeader(true).party(savedParty).build();
+        memberRepo.save(partyMember1);
         final PartyMember partyMember2 = PartyMember.builder().user(savedUser2).party(savedParty).build();
         memberRepo.save(partyMember2);
         final PartyMember partyMember3 = PartyMember.builder().user(savedUser3).party(savedParty).build();
         memberRepo.save(partyMember3);
 
         //then
-        assertEquals(savedParty, memberRepo.findPartyByUserId(savedUser2).get());
-
-        List<User> members = memberRepo.findUsersByParty(savedParty);
-        assertEquals(true, members.contains(savedUser2));
-        assertEquals(true, members.contains(savedUser3));
+        assertEquals(partyMember2, memberRepo.findOneByUser(savedUser2).get());
     }
 
-     */
+    @Test
+    void Party로_PartyMember들_찾기_테스트() {
+        //given
+        final User user1 = User.builder().userId("유저1").build();
+        final User savedUser1 = userRepo.save(user1);
+        final User user2 = User.builder().userId("유저2").build();
+        final User savedUser2 = userRepo.save(user2);
+        final User user3 = User.builder().userId("유저3").build();
+        final User savedUser3 = userRepo.save(user3);
 
+        final Party party = Party.builder().ottId("id").ottPassword("pass").build();
+        final Party savedParty = partyRepo.save(party);
+
+        //when
+        final PartyMember partyMember1 = PartyMember.builder().user(savedUser1).isLeader(true).party(savedParty).build();
+        memberRepo.save(partyMember1);
+        final PartyMember partyMember2 = PartyMember.builder().user(savedUser2).party(savedParty).build();
+        memberRepo.save(partyMember2);
+        final PartyMember partyMember3 = PartyMember.builder().user(savedUser3).party(savedParty).build();
+        memberRepo.save(partyMember3);
+
+        //then
+        List<PartyMember> members = memberRepo.findByParty(savedParty);
+        assertEquals(true, members.contains(partyMember1));
+        assertEquals(true, members.contains(partyMember2));
+        assertEquals(true, members.contains(partyMember3));
+    }
 }

--- a/src/test/java/kr/flab/ottsharing/repository/PartyMemberRepositoryTest.java
+++ b/src/test/java/kr/flab/ottsharing/repository/PartyMemberRepositoryTest.java
@@ -1,25 +1,15 @@
 package kr.flab.ottsharing.repository;
 
-import static org.junit.Assert.*;
-
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
-
-import kr.flab.ottsharing.entity.Party;
-import kr.flab.ottsharing.entity.PartyMember;
-import kr.flab.ottsharing.entity.User;
-
-import java.util.List;
 
 @ExtendWith(SpringExtension.class)
 @DataJpaTest
 @TestPropertySource("classpath:application-test.yml")
-public class PartyMemberTest {
+public class PartyMemberRepositoryTest {
 
     @Autowired
     private PartyMemberRepository memberRepo;


### PR DESCRIPTION
* PartyMember Entity 구조 개선
* PartyMemberRepository 구조 개선
  * 요구사항에서는 userId, partyId로 찾게했으나 그렇게 짜는 방법이 까다롭고, 보통 해당 엔티티(User, Party)를 얻은 뒤에나 이 메소드를 호출할 것이라고 생각되어
  * userId, partyId가 아닌 user, party로 찾게 했음 (findOneByUser, findByParty)

* PartyMemberTest -> PartyMemberRepositoryTest 테스트 클래스 이름 변경