### PR TITLE
PartyWating - Entity & Repository 개선 #33

### DIFF
--- a/src/main/java/kr/flab/ottsharing/entity/PartyWaiting.java
+++ b/src/main/java/kr/flab/ottsharing/entity/PartyWaiting.java
@@ -7,6 +7,7 @@ import javax.persistence.*;
 
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.format.annotation.DateTimeFormat;
 
 @Entity
@@ -15,7 +16,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Table(name = "partyWaiting")
+@Table(name = "party_waiting")
 public class PartyWaiting {
     @Id
     @Column(name="waiting_id")
@@ -31,4 +32,8 @@ public class PartyWaiting {
     @CreationTimestamp
     private LocalDateTime createdTime;
 
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
+    @Column(name ="updated_timestamp")
+    @UpdateTimestamp
+    private LocalDateTime updatedTime;
 }

--- a/src/main/java/kr/flab/ottsharing/repository/PartyWaitingRepository.java
+++ b/src/main/java/kr/flab/ottsharing/repository/PartyWaitingRepository.java
@@ -1,5 +1,7 @@
 package kr.flab.ottsharing.repository;
 
+import java.util.List;
+
 import kr.flab.ottsharing.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,7 +15,7 @@ public interface PartyWaitingRepository extends JpaRepository<PartyWaiting, Inte
 
     void deleteByUser(User user);
 
-    Iterable<PartyWaiting> findTop3ByOrderByCreatedTimeAsc();
+    List<PartyWaiting> findTop3ByOrderByCreatedTimeAsc();
 
     boolean existsBy();
 }

--- a/src/main/java/kr/flab/ottsharing/repository/PartyWaitingRepository.java
+++ b/src/main/java/kr/flab/ottsharing/repository/PartyWaitingRepository.java
@@ -9,15 +9,11 @@ import kr.flab.ottsharing.entity.PartyWaiting;
 
 @Repository
 public interface PartyWaitingRepository extends JpaRepository<PartyWaiting, Integer> {
-    @Override
-    <S extends PartyWaiting> S save(S entity);
-
     boolean existsByUser(User user);
 
-    Iterable<PartyWaiting> findTop3ByOrderByCreatedTimeAsc();
+    void deleteByUser(User user);
 
-    @Override
-    void deleteById(Integer id);
+    Iterable<PartyWaiting> findTop3ByOrderByCreatedTimeAsc();
 
     boolean existsBy();
 }

--- a/src/main/java/kr/flab/ottsharing/service/LoginService.java
+++ b/src/main/java/kr/flab/ottsharing/service/LoginService.java
@@ -15,11 +15,13 @@ public class LoginService {
 
     private final UserRepository userRepository;
 
-    public User loginCheck(String loginId) {
+    // User Repository 구조 개편으로 코드 정상적으로 동작하지 않음
+    public User loginCheck(String loginId) {/*
         Optional<User> user = userRepository.findById(loginId);
         if(user.isPresent()){
             return user.get();
         }
+        */
 
         return null;
     }

--- a/src/main/java/kr/flab/ottsharing/service/MyPartyService.java
+++ b/src/main/java/kr/flab/ottsharing/service/MyPartyService.java
@@ -21,7 +21,10 @@ public class MyPartyService {
     @Autowired
     private PartyWaitingRepository waitRepo;
 
+
     public MyParty getMyParty(String userId) {
+        // User Repository 구조 변경으로 인해 코드 동작하지 않음
+        /*
         if (userId == null || userId.isEmpty()) {
             return new MyParty(MyParty.Status.NOT_LOGIN);
         }
@@ -38,5 +41,7 @@ public class MyPartyService {
         }
 
         return new MyParty(MyParty.Status.HAS_NO_PARTY);
+        */
+        return null;
     }
 }

--- a/src/main/java/kr/flab/ottsharing/service/PartyService.java
+++ b/src/main/java/kr/flab/ottsharing/service/PartyService.java
@@ -22,12 +22,16 @@ public class PartyService {
     private final PartyMemberRepository memberRepo;
 
     public Party enrollParty(String leaderId,String getottId, String getottPassword){
+        // User Repository 구조 개편으로 코드 정상적으로 동작하지 않음
+        /*
 
         User teamleader = userRepo.getById(leaderId);
         Party party = Party.builder().leader(teamleader).ottId(getottId).ottPassword(getottPassword).build();
         Party enrolledParty = partyRepo.save(party);
 
         return enrolledParty;
+        */
+        return null;
     }
 
     public boolean makeFull(Party party){
@@ -44,9 +48,12 @@ public class PartyService {
     }
 
     public void getInParty(String userId, Party pickParty){
+        // User Repository 구조 개편으로 코드 정상적으로 동작하지 않음
+        /*
         User userToJoin = userRepo.getById(userId);
         PartyMember member = PartyMember.builder().user(userToJoin).party(pickParty).build();
         memberRepo.save(member);
+        */
     }
 
 }

--- a/src/main/java/kr/flab/ottsharing/service/PartyWaitingService.java
+++ b/src/main/java/kr/flab/ottsharing/service/PartyWaitingService.java
@@ -37,10 +37,11 @@ public class PartyWaitingService {
     }
 
     public void putWaitingList(String waitmemberId){
-
+        // User Repository 변경으로 인해 코드 정상적으로 동작하지 않음
+        /*
         User waitmember = userRepo.getById(waitmemberId);
         PartyWaiting member = PartyWaiting.builder().user(waitmember).build();
         waitRepo.save(member);
-
+        */
     }
 }

--- a/src/test/java/kr/flab/ottsharing/repository/PartyWaitingRepositoryTest.java
+++ b/src/test/java/kr/flab/ottsharing/repository/PartyWaitingRepositoryTest.java
@@ -25,24 +25,36 @@ public class PartyWaitingRepositoryTest {
     private UserRepository userRepo;
 
     @Test
-    void 대기자_등록_삭제_테스트() {
+    void save_테스트() {
         // given
         final User user = User.builder().userId("user").build();
         final User savedUser = userRepo.save(user);
 
         // when
         final PartyWaiting wait = PartyWaiting.builder().user(savedUser).build();
-        final PartyWaiting savedWait = waitRepo.save(wait);
 
         // then
+        final PartyWaiting savedWait = waitRepo.save(wait);
         assertEquals(waitRepo.findById(savedWait.getWaitingId()).get(), savedWait);
+    }
 
-        waitRepo.deleteById(savedWait.getWaitingId());
+    @Test
+    void deleteByUser_테스트() {
+        // given
+        final User user = User.builder().userId("user").build();
+        final User savedUser = userRepo.save(user);
+
+        // when
+        final PartyWaiting wait = PartyWaiting.builder().user(savedUser).build();
+        waitRepo.save(wait);
+
+        // then
+        waitRepo.deleteByUser(user);
         assertEquals(waitRepo.count(), 0);
     }
 
     @Test
-    void 가장_오래된_대기자_세명_가져오기_테스트() {
+    void findTop3ByOrderByCreatedTimeAsc_테스트() {
         // given
         User[] users = new User[5];
         PartyWaiting[] waits = new PartyWaiting[5];
@@ -66,5 +78,36 @@ public class PartyWaitingRepositoryTest {
             assertEquals(String.valueOf(userNumber), top3Wait.getUser().getUserId());
             userNumber++;
         }
+    }
+
+    @Test
+    void existsByUser_테스트() {
+        // given
+        final User user1 = User.builder().userId("user1").build();
+        final User savedUser1 = userRepo.save(user1);
+
+        final PartyWaiting wait = PartyWaiting.builder().user(savedUser1).build();
+        waitRepo.save(wait);
+
+        final User user2 = User.builder().userId("user2").build();
+        final User savedUser2 = userRepo.save(user2);
+
+
+        // then
+        assertEquals(true, waitRepo.existsByUser(savedUser1));
+        assertEquals(false, waitRepo.existsByUser(savedUser2));
+    }
+
+    @Test
+    void existsBy_테스트() {
+        assertEquals(false, waitRepo.existsBy());
+
+        final User user = User.builder().userId("user").build();
+        final User savedUser = userRepo.save(user);
+
+        final PartyWaiting wait = PartyWaiting.builder().user(savedUser).build();
+        waitRepo.save(wait);
+
+        assertEquals(true, waitRepo.existsBy());
     }
 }

--- a/src/test/java/kr/flab/ottsharing/repository/UserRepositoryTest.java
+++ b/src/test/java/kr/flab/ottsharing/repository/UserRepositoryTest.java
@@ -1,25 +1,16 @@
 package kr.flab.ottsharing.repository;
 
-import java.util.List;
-import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.*;
 
-import lombok.RequiredArgsConstructor;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.transaction.annotation.Transactional;
 
 import kr.flab.ottsharing.entity.User;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(SpringExtension.class)
 @DataJpaTest


### PR DESCRIPTION
* PartyWaiting Entity 구조 개선
* PartyWaiting Repository 구조 개선
  * save, deleteById 삭제 (이미 구현된 것은 추가 선언 안하기로 정했기때문)
  * 최종적으로 existsByUser, deleteByUser, findTop3ByorderByCreatedTimeAsc, existsBy만 남김
* PartyWaitingRepository에서 사용할 메서드들에 대한 테스트케이스 작성 (선언된 것 + save, deleteById)

컴파일 에러 대응
* User Repository 구조 개선으로 인해 컴파일 에러 나는 코드들 주석처리
* UserRepositoryTest에서 Optimize imports
  * lombok import에서 컴파일에러까지 발생했기때문에 불가피했음