### PR TITLE
UserService - deleteMyInfo #40

### DIFF
--- a/src/main/java/kr/flab/ottsharing/protocol/UserDeleteResult.java
+++ b/src/main/java/kr/flab/ottsharing/protocol/UserDeleteResult.java
@@ -1,0 +1,5 @@
+package kr.flab.ottsharing.protocol;
+
+public enum UserDeleteResult {
+    HAS_MONEY, HAS_PARTY, SUCCESS
+}

--- a/src/main/java/kr/flab/ottsharing/service/UserService.java
+++ b/src/main/java/kr/flab/ottsharing/service/UserService.java
@@ -3,6 +3,8 @@ package kr.flab.ottsharing.service;
 import org.springframework.stereotype.Service;
 
 import kr.flab.ottsharing.entity.User;
+import kr.flab.ottsharing.protocol.UserDeleteResult;
+import kr.flab.ottsharing.repository.PartyMemberRepository;
 import kr.flab.ottsharing.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -11,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PartyMemberRepository partyMemberRepository;
 
 
     // User Repository 구조 변경으로 인해 동작하지 않는 코드
@@ -24,12 +27,31 @@ public class UserService {
         return null;
     }
 
+    // User Entity 구조 변경으로 인해 동작하지 않는 코드
     public User enrollUser(String loginId){
+        /*
         User user = User.builder()
             .userId(loginId)
             .build();
 
         User savedUser = userRepository.save(user);
         return savedUser;
+        */
+        return null;
+    }
+
+    // userId는 로그인 된 아이디를 컨트롤러에서 넘겨준다고 전제함
+    // JWT /login이 구현되면 추후 수정
+    public UserDeleteResult deleteMyInfo(String userId) {
+        User user = userRepository.findByUserId(userId);
+        if (user.getMoney() > 0) {
+            return UserDeleteResult.HAS_MONEY;
+        }
+        if (partyMemberRepository.findOneByUser(user).isPresent()) {
+            return UserDeleteResult.HAS_PARTY;
+        }
+
+        userRepository.deleteById(user.getId());
+        return UserDeleteResult.SUCCESS;
     }
 }


### PR DESCRIPTION
* [feature/89](https://github.com/f-lab-edu/ottsharing/issues/89) 브랜치를 베이스로 만들었음

* UserDeleteResult 프로토콜 구현
  * 탈퇴 결과 반환 (돈 있거나 파티 있어서 안됨, 성공)

* UserService deleteMyInfo 구현
  * 돈도 없고 파티도 없어야 탈퇴가 되도록 함
  * userId는 로그인 된 아이디를 컨트롤러에서 넘겨준다고 전제함
  * JWT login이 구현되면 추후 수정