### PR TITLE
파티 해체 api 구현 #49#53

### DIFF
--- a/src/main/java/kr/flab/ottsharing/controller/PartyController.java
+++ b/src/main/java/kr/flab/ottsharing/controller/PartyController.java
@@ -36,7 +36,7 @@ public class PartyController {
     }
 
     @DeleteMapping("/party/deleteParty")
-    public void deleteParty(@RequestParam String userId, @RequestParam Integer partyId) {
-        partyServ.deleteParty(userId, partyId);
+    public String deleteParty(@RequestParam String userId, @RequestParam Integer partyId) {
+        return partyServ.deleteParty(userId, partyId);
     }
 }

--- a/src/main/java/kr/flab/ottsharing/service/LeaderMemberService.java
+++ b/src/main/java/kr/flab/ottsharing/service/LeaderMemberService.java
@@ -20,7 +20,7 @@ public class LeaderMemberService {
         return member.isLeader();
     }
 
-    public Party PartyOfLeader(){
+    public Party getPartyOfLeader(){
         return member.getParty();
     }
     

--- a/src/main/java/kr/flab/ottsharing/service/LeaderMemberService.java
+++ b/src/main/java/kr/flab/ottsharing/service/LeaderMemberService.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class PartyMemberService {
+public class LeaderMemberService {
 
     private final PartyMemberRepository memberRepo;
     private PartyMember member;
@@ -23,5 +23,6 @@ public class PartyMemberService {
     public Party PartyOfLeader(){
         return member.getParty();
     }
+    
     
 }

--- a/src/main/java/kr/flab/ottsharing/service/PartyMemberService.java
+++ b/src/main/java/kr/flab/ottsharing/service/PartyMemberService.java
@@ -15,12 +15,12 @@ public class PartyMemberService {
     private final PartyMemberRepository memberRepo;
     private PartyMember member;
 
-    public Boolean checkLeader(User user){
+    public Boolean checkLeader(User user) {
         member = memberRepo.findOneByUser(user).get();
         return member.isLeader();
     }
 
-    public Party getPartyOfLeader(){
+    public Party getPartyOfLeader() {
         return member.getParty();
     }
 }

--- a/src/main/java/kr/flab/ottsharing/service/PartyMemberService.java
+++ b/src/main/java/kr/flab/ottsharing/service/PartyMemberService.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class LeaderMemberService {
+public class PartyMemberService {
 
     private final PartyMemberRepository memberRepo;
     private PartyMember member;
@@ -23,6 +23,4 @@ public class LeaderMemberService {
     public Party getPartyOfLeader(){
         return member.getParty();
     }
-    
-    
 }

--- a/src/main/java/kr/flab/ottsharing/service/PartyService.java
+++ b/src/main/java/kr/flab/ottsharing/service/PartyService.java
@@ -48,17 +48,17 @@ public class PartyService {
     public void deleteParty(String userId, Integer partyId) {
 
         Optional<User> user = userRepo.findByUserId(userId);
-        System.out.println(user);
+
         if(user.isPresent()) {
             User presentUser = user.get();
-         
+
             if (memberService.checkLeader(presentUser)) {
                 Party party = memberService.PartyOfLeader();
 
                 if (party.getPartyId().equals(partyId)) {
-           
+
                     memberRepo.deleteAllByParty(party);
-       
+
                     partyRepo.deleteById(partyId);
 
                 } else {
@@ -71,6 +71,7 @@ public class PartyService {
             throw new WrongInfoException("존재하지 않는 회원id를 입력했습니다" + userId );
         }
     }
+
 
 
     // Party Entity 구조 변경으로 인해 동작하지 않는 코드

--- a/src/main/java/kr/flab/ottsharing/service/PartyService.java
+++ b/src/main/java/kr/flab/ottsharing/service/PartyService.java
@@ -32,7 +32,6 @@ public class PartyService {
             .ottPassword(ottPassword)
             .build();
         partyRepo.save(party);
-        
         PartyMember member = PartyMember.builder()
             .user(leader)
             .isLeader(true)

--- a/src/main/java/kr/flab/ottsharing/service/PartyService.java
+++ b/src/main/java/kr/flab/ottsharing/service/PartyService.java
@@ -24,7 +24,7 @@ public class PartyService {
     private final PartyRepository partyRepo;
     private final PartyMemberRepository memberRepo;
     private final UserRepository userRepo;
-    private final PartyMemberService memberService;
+    private final LeaderMemberService leadermemberService;
 
     public PartyCreateResult create(User leader, String ottId, String ottPassword) {
         Party party = Party.builder()
@@ -52,8 +52,8 @@ public class PartyService {
         if(user.isPresent()) {
             User presentUser = user.get();
 
-            if (memberService.checkLeader(presentUser)) {
-                Party party = memberService.PartyOfLeader();
+            if (leadermemberService.checkLeader(presentUser)) {
+                Party party = leadermemberService.PartyOfLeader();
 
                 if (party.getPartyId().equals(partyId)) {
 
@@ -71,6 +71,8 @@ public class PartyService {
             throw new WrongInfoException("존재하지 않는 회원id를 입력했습니다" + userId );
         }
     }
+
+
 
 
 

--- a/src/main/java/kr/flab/ottsharing/service/PartyService.java
+++ b/src/main/java/kr/flab/ottsharing/service/PartyService.java
@@ -45,7 +45,7 @@ public class PartyService {
     }
 
     @Transactional
-    public void deleteParty(String userId, Integer partyId) {
+    public String deleteParty(String userId, Integer partyId) {
 
         Optional<User> user = userRepo.findByUserId(userId);
 
@@ -60,7 +60,7 @@ public class PartyService {
                     memberRepo.deleteAllByParty(party);
 
                     partyRepo.deleteById(partyId);
-
+                    return "삭제 완료되었습니다";
                 } else {
                     throw new WrongInfoException("삭제 권한의 그룹이 아닙니다" + partyId );
                 }

--- a/src/main/java/kr/flab/ottsharing/service/PartyService.java
+++ b/src/main/java/kr/flab/ottsharing/service/PartyService.java
@@ -6,16 +6,16 @@ import java.util.Optional;
 import javax.transaction.Transactional;
 
 import org.springframework.stereotype.Service;
+
 import kr.flab.ottsharing.entity.Party;
 import kr.flab.ottsharing.entity.PartyMember;
-import kr.flab.ottsharing.repository.PartyMemberRepository;
-import kr.flab.ottsharing.repository.PartyRepository;
-import kr.flab.ottsharing.repository.UserRepository;
 import kr.flab.ottsharing.entity.User;
 import kr.flab.ottsharing.exception.WrongInfoException;
 import kr.flab.ottsharing.protocol.PartyCreateResult;
+import kr.flab.ottsharing.repository.PartyMemberRepository;
+import kr.flab.ottsharing.repository.PartyRepository;
+import kr.flab.ottsharing.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +24,7 @@ public class PartyService {
     private final PartyRepository partyRepo;
     private final PartyMemberRepository memberRepo;
     private final UserRepository userRepo;
-    private final LeaderMemberService leadermemberService;
+    private final PartyMemberService leadermemberService;
 
     public PartyCreateResult create(User leader, String ottId, String ottPassword) {
         Party party = Party.builder()
@@ -48,19 +48,16 @@ public class PartyService {
     public String deleteParty(String userId, Integer partyId) {
 
         Optional<User> user = userRepo.findByUserId(userId);
-         
-        if(!user.isPresent()) {
+        if (!user.isPresent()) {
             throw new WrongInfoException("존재하지 않는 회원id를 입력했습니다" + userId );
         }
         User presentUser = user.get();
-        
-        if(!leadermemberService.checkLeader(presentUser)) {
+        if (!leadermemberService.checkLeader(presentUser)) {
             throw new WrongInfoException("삭제 권한이 없습니다" + userId );
         }
-       
         Party party = leadermemberService.getPartyOfLeader();
 
-        if(!party.getPartyId().equals(partyId)) {
+        if (!party.getPartyId().equals(partyId)) {
             throw new WrongInfoException("삭제 권한의 그룹이 아닙니다" + partyId );
         }
 

--- a/src/main/java/kr/flab/ottsharing/service/PartyService.java
+++ b/src/main/java/kr/flab/ottsharing/service/PartyService.java
@@ -48,29 +48,28 @@ public class PartyService {
     public String deleteParty(String userId, Integer partyId) {
 
         Optional<User> user = userRepo.findByUserId(userId);
-
-        if(user.isPresent()) {
-            User presentUser = user.get();
-
-            if (leadermemberService.checkLeader(presentUser)) {
-                Party party = leadermemberService.PartyOfLeader();
-
-                if (party.getPartyId().equals(partyId)) {
-
-                    memberRepo.deleteAllByParty(party);
-
-                    partyRepo.deleteById(partyId);
-                    return "삭제 완료되었습니다";
-                } else {
-                    throw new WrongInfoException("삭제 권한의 그룹이 아닙니다" + partyId );
-                }
-            } else {
-                throw new WrongInfoException("삭제 권한이 없습니다" + userId );
-            }
-        } else {
+         
+        if(!user.isPresent()) {
             throw new WrongInfoException("존재하지 않는 회원id를 입력했습니다" + userId );
         }
+        User presentUser = user.get();
+        
+        if(!leadermemberService.checkLeader(presentUser)) {
+            throw new WrongInfoException("삭제 권한이 없습니다" + userId );
+        }
+       
+        Party party = leadermemberService.getPartyOfLeader();
+
+        if(!party.getPartyId().equals(partyId)) {
+            throw new WrongInfoException("삭제 권한의 그룹이 아닙니다" + partyId );
+        }
+
+        memberRepo.deleteAllByParty(party);
+        partyRepo.deleteById(partyId);
+
+        return "삭제 완료되었습니다";
     }
+
 
 
 


### PR DESCRIPTION
* 파티멤버들 삭제 후 파티 완전 삭제하도록 함
* 파티의 리더만 권한 부여
* 리더가 속한 파티인지 확인 후 해체
* Exception 기능 추가 
* postman으로 테스트 진행
* 항목들  
PartyController, PartyService -> api 기능 구현 
PartyMemberRepository, PartyRepository ->  delete 쿼리 추가
application.yml -> deleteMapping 이용을 위한 조치 추가
WrongInfoException -> RuntimeException을 확장함. 조건에 해당되지 않을 경우 예외발생