### PR TITLE
feat: 파티 해체 및 리더확인 기능 구현

### DIFF
--- a/src/main/java/kr/flab/ottsharing/controller/PartyController.java
+++ b/src/main/java/kr/flab/ottsharing/controller/PartyController.java
@@ -1,5 +1,6 @@
 package kr.flab.ottsharing.controller;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,5 +33,10 @@ public class PartyController {
             waitingServ.putWaitingList(userId);
             return "파티 참여 대기중입니다";
         }
+    }
+
+    @DeleteMapping("/party/deleteParty")
+    public String deleteParty(@RequestParam String userId, @RequestParam Integer partyId) {
+        return partyServ.deleteParty(userId, partyId);
     }
 }

--- a/src/main/java/kr/flab/ottsharing/repository/PartyMemberRepository.java
+++ b/src/main/java/kr/flab/ottsharing/repository/PartyMemberRepository.java
@@ -15,4 +15,6 @@ public interface PartyMemberRepository extends JpaRepository<PartyMember,Integer
     Optional<PartyMember> findOneByUser(User user);
 
     List<PartyMember> findByParty(Party party);
+
+    void deleteAllByParty(Party party);
 }

--- a/src/main/java/kr/flab/ottsharing/repository/PartyRepository.java
+++ b/src/main/java/kr/flab/ottsharing/repository/PartyRepository.java
@@ -16,4 +16,6 @@ public interface PartyRepository extends JpaRepository<Party,Integer> {
 
     @Query(value = "select p from Party p where p.isFull = false order by p.createdTime asc")
     List<Party> findNotFullOldestParties();
+
+    void deleteById(Integer partyId);
 }

--- a/src/main/java/kr/flab/ottsharing/repository/UserRepository.java
+++ b/src/main/java/kr/flab/ottsharing/repository/UserRepository.java
@@ -1,5 +1,7 @@
 package kr.flab.ottsharing.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import kr.flab.ottsharing.entity.User;
 import org.springframework.stereotype.Repository;
@@ -11,7 +13,7 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 
     boolean existsByEmail(String email);
 
-    User findByUserId(String userId);
+    Optional<User> findByUserId(String userId);
 
     void deleteById(Integer id);
 }

--- a/src/main/java/kr/flab/ottsharing/service/PartyMemberService.java
+++ b/src/main/java/kr/flab/ottsharing/service/PartyMemberService.java
@@ -1,0 +1,21 @@
+package kr.flab.ottsharing.service;
+
+import org.springframework.stereotype.Service;
+
+import kr.flab.ottsharing.entity.Party;
+import kr.flab.ottsharing.entity.PartyMember;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PartyMemberService {
+
+    public Boolean checkLeader(PartyMember partymember) {
+        return partymember.isLeader();
+    }
+
+    public Party getPartyOfLeader(PartyMember partymember) {
+        return partymember.getParty();
+
+    }
+}

--- a/src/main/java/kr/flab/ottsharing/service/PartyService.java
+++ b/src/main/java/kr/flab/ottsharing/service/PartyService.java
@@ -1,11 +1,17 @@
 package kr.flab.ottsharing.service;
 
 import java.util.List;
+import java.util.Optional;
+
+import javax.transaction.Transactional;
+
 import org.springframework.stereotype.Service;
 import kr.flab.ottsharing.entity.Party;
 import kr.flab.ottsharing.entity.PartyMember;
 import kr.flab.ottsharing.repository.PartyMemberRepository;
 import kr.flab.ottsharing.repository.PartyRepository;
+import kr.flab.ottsharing.repository.UserRepository;
+import kr.flag.ottsharing.exception.WrongInfoException;
 import kr.flab.ottsharing.entity.User;
 import kr.flab.ottsharing.protocol.PartyCreateResult;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +23,8 @@ public class PartyService {
 
     private final PartyRepository partyRepo;
     private final PartyMemberRepository memberRepo;
+    private final UserRepository userRepo;
+    private final PartyMemberService partymemberService;
 
     public PartyCreateResult create(User leader, String ottId, String ottPassword) {
         Party party = Party.builder()
@@ -36,6 +44,31 @@ public class PartyService {
         return PartyCreateResult.SUCCESS;
     }
 
+    @Transactional
+    public String deleteParty(String userId, Integer partyId) {
+
+        Optional<User> user = userRepo.findByUserId(userId);
+        if (!user.isPresent()) {
+            throw new WrongInfoException("존재하지 않는 회원id를 입력했습니다" + userId );
+        }
+        User presentUser = user.get();
+        PartyMember partymember = memberRepo.findOneByUser(presentUser).get();
+
+        if (!partymemberService.checkLeader(partymember)) {
+            throw new WrongInfoException("삭제 권한이 없습니다" + userId );
+        }
+
+        Party party = partymemberService.getPartyOfLeader(partymember);
+
+        if (!party.getPartyId().equals(partyId)) {
+            throw new WrongInfoException("삭제 권한의 그룹이 아닙니다" + partyId );
+        }
+
+        memberRepo.deleteAllByParty(party);
+        partyRepo.deleteById(partyId);
+
+        return "삭제 완료되었습니다";
+    }
 
     // Party Entity 구조 변경으로 인해 동작하지 않는 코드
     public Party enrollParty(String leaderId, String getottId, String getottPassword) {

--- a/src/main/java/kr/flab/ottsharing/service/UserService.java
+++ b/src/main/java/kr/flab/ottsharing/service/UserService.java
@@ -105,7 +105,7 @@ public class UserService {
     // userId는 로그인 된 아이디를 컨트롤러에서 넘겨준다고 전제함
     // JWT /login이 구현되면 추후 수정
     public UserDeleteResult deleteMyInfo(String userId) {
-        User user = userRepository.findByUserId(userId);
+        User user = userRepository.findByUserId(userId).get();
         if (user.getMoney() > 0) {
             return UserDeleteResult.HAS_MONEY;
         }
@@ -120,13 +120,13 @@ public class UserService {
     // login이 된 자신의 아이디만 넣어 호출한다는 전제하에 작성하였음
     // 추후 login 구현됐을때 현재 로그인 된 아이디로 호출하게끔 수정 필요
     public MyInfo fetchMyInfo(String userId) {
-        User user = userRepository.findByUserId(userId);
+        User user = userRepository.findByUserId(userId).get();
         return new MyInfo(userId, user.getEmail(), user.getMoney());
     }
 
     public MyPageUpdateResult updateMyInfo(String userId, String changedPassword, String changedEmail) {
 
-        User user = userRepository.findByUserId(userId);
+        User user = userRepository.findByUserId(userId).get();
         String passwordBeforeChange = user.getUserPassword();
         String emailBeforeChange = user.getEmail();
         boolean emailProblem = false;

--- a/src/main/java/kr/flag/ottsharing/exception/WrongInfoException.java
+++ b/src/main/java/kr/flag/ottsharing/exception/WrongInfoException.java
@@ -1,0 +1,8 @@
+package kr.flag.ottsharing.exception;
+
+public class WrongInfoException extends RuntimeException{
+
+    public WrongInfoException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,9 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher # Spring boot 2.6버전 이후부터 발생하는 Swagger3.0.0 충돌 문제 해결하기 위한 설정
+    hiddenmethod:
+      filter:
+        enabled: true
   jpa:
     hibernate:
       dialect: org.hibernate.dialect.MariaDBDialect

--- a/src/test/java/kr/flab/ottsharing/repository/UserRepositoryTest.java
+++ b/src/test/java/kr/flab/ottsharing/repository/UserRepositoryTest.java
@@ -36,7 +36,7 @@ public class UserRepositoryTest {
     @Test
     void 가입_테스트(){
 
-        User result = userRepository.findByUserId(user1.getUserId());
+        User result = userRepository.findByUserId(user1.getUserId()).get();
         assertEquals("유저1", result.getUserId());
         assertEquals("1234", result.getUserPassword());
         assertEquals("email1", result.getEmail());


### PR DESCRIPTION
* 리더 확인 메소드 구현- 관련 항목 : PartyMemberService
* 파티 해체 api
 --파티멤버들 삭제 후 파티 완전 삭제하도록 함
 -- 파티의 리더만 권한 부여
 -- 리더가 속한 파티인지 확인 후 해체
 -- Exception 기능 추가
 -- postman으로 테스트 진행
 -- UserRepository의 findByUserId을 Optional타입으로 변경
     기존의 findByUserId을 사용하는 부분에 .get() 추가시켜 기존 코드 문제없게 함.
 -- 관련 항목
PartyController, PartyService -> api 기능 구현
PartyMemberRepository, PartyRepository -> delete 쿼리 추가
application.yml -> deleteMapping 이용을 위한 조치 추가
WrongInfoException -> RuntimeException을 확장함. 조건에 해당되지 않을 경우 예외발생