### PR TITLE
feat : 파티정보 수정 api 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation', version: '2.5.6'
 	implementation 'junit:junit:4.13.2'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/kr/flab/ottsharing/controller/PartyController.java
+++ b/src/main/java/kr/flab/ottsharing/controller/PartyController.java
@@ -1,23 +1,25 @@
 package kr.flab.ottsharing.controller;
 
+import javax.validation.Valid;
+
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import kr.flab.ottsharing.entity.User;
 import kr.flab.ottsharing.protocol.MyParty;
 import kr.flab.ottsharing.protocol.PartyCreateResult;
+import kr.flab.ottsharing.protocol.UpdatePartyInfo;
 import kr.flab.ottsharing.service.PartyService;
-import kr.flab.ottsharing.service.PartyWaitingService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 public class PartyController {
     private final PartyService partyServ;
-    private final PartyWaitingService waitingServ;
 
     @PostMapping("/party/create")
     public PartyCreateResult create(@RequestParam String ottId, @RequestParam String ottPassword) {
@@ -53,5 +55,10 @@ public class PartyController {
     @DeleteMapping("/party/getOutParty")
     public String getOutParty(@RequestParam String userId, @RequestParam Integer partyId) {
         return partyServ.getOutParty(userId, partyId);
+    }
+
+    @PostMapping("/party/updatePartyInfo")
+    public String updatePartyInfo(@Valid @RequestBody UpdatePartyInfo info) {
+        return partyServ.updatePartyInfo(info);
     }
 }

--- a/src/main/java/kr/flab/ottsharing/entity/PartyMember.java
+++ b/src/main/java/kr/flab/ottsharing/entity/PartyMember.java
@@ -21,6 +21,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 
 @Builder
@@ -28,6 +29,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 @Entity
+@Setter
 @Table(name = "party_member")
 public class PartyMember {
     @Id

--- a/src/main/java/kr/flab/ottsharing/protocol/UpdatePartyInfo.java
+++ b/src/main/java/kr/flab/ottsharing/protocol/UpdatePartyInfo.java
@@ -1,0 +1,26 @@
+package kr.flab.ottsharing.protocol;
+
+import javax.validation.constraints.NotBlank;
+
+import org.springframework.lang.Nullable;
+
+import lombok.Getter;
+
+@Getter
+public class UpdatePartyInfo {
+    @Nullable
+    private String ottId;
+
+    @Nullable
+    private String ottPassword;
+
+    @Nullable
+    private String nicknameToChange;
+
+    @NotBlank(message = "아이디 입력이 반드시 필요합니다.")
+    private String userId;
+
+    @NotBlank(message = "그룹Id 정보가 반드시 필요합니다.")
+    private Integer partyId;
+
+}

--- a/src/main/java/kr/flab/ottsharing/service/PartyMemberService.java
+++ b/src/main/java/kr/flab/ottsharing/service/PartyMemberService.java
@@ -1,14 +1,24 @@
 package kr.flab.ottsharing.service;
 
+import java.util.List;
+
+import org.hibernate.WrongClassException;
 import org.springframework.stereotype.Service;
 
 import kr.flab.ottsharing.entity.Party;
 import kr.flab.ottsharing.entity.PartyMember;
+import kr.flab.ottsharing.exception.WrongInfoException;
+import kr.flab.ottsharing.protocol.UpdatePartyInfo;
+import kr.flab.ottsharing.repository.PartyMemberRepository;
+import kr.flab.ottsharing.repository.PartyRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class PartyMemberService {
+
+    private final PartyRepository partyRepo;
+    private final PartyMemberRepository partyMemberRepo;
 
     public Boolean checkLeader(PartyMember partyMember) {
         return partyMember.isLeader();
@@ -17,4 +27,86 @@ public class PartyMemberService {
     public Party getParty(PartyMember partyMember) {
         return partyMember.getParty();
     }
+
+    public String changeInfoOfLeader(PartyMember partyMember, Party party, UpdatePartyInfo info) {
+
+        boolean hasNickname = false;
+        boolean hasOttId = false;
+        boolean hasOttPassword = false;
+        boolean saveParty = false;
+        String nickname = info.getNicknameToChange();
+        String ottId = info.getOttId();
+        String ottPassword = info.getOttPassword();
+
+        if (info.getNicknameToChange() != null) {
+            hasNickname = true;
+        }
+
+        if (info.getOttId() != null) {
+            hasOttId = true;
+        }
+
+        if (info.getOttPassword() != null) {
+            hasOttPassword = true;
+        }
+
+        if (!hasNickname && !hasOttId && !hasOttPassword) {
+            throw new WrongInfoException("바꿀 정보가 아무것도 입력되지 않았습니다.");
+        }
+        
+        if (hasNickname) {
+            checkNickNameDuplicate(party, nickname);
+            partyMember.setNickname(nickname);
+            partyMemberRepo.save(partyMember);
+        }
+
+        if (hasOttId) {
+            party.setOttId(ottId);
+            saveParty = true;
+        }
+
+        if (hasOttPassword) {
+            party.setOttPassword(ottPassword);
+            saveParty = true;
+        }
+
+        if(saveParty == true) {
+            partyRepo.save(party);
+        }
+        
+        return "리더의 요청으로 파티 정보 수정 완료되었습니다.";
+    }
+
+    public String changeInfoOfMember(PartyMember partyMember, Party party, UpdatePartyInfo info) {
+        
+        String nickname = info.getNicknameToChange();
+        String ottId = info.getOttId();
+        String ottPassword = info.getOttPassword();
+
+        if (ottId != null || ottPassword != null) {
+            throw new WrongInfoException("팀원은 파티의 아이디 또는 패스워드를 수정할 수 없습니다. ");
+        }
+
+        if (nickname == null) {
+            throw new WrongInfoException("바꿀 닉네임을 적어줘야 합니다." + nickname);
+        }
+
+        checkNickNameDuplicate(party, nickname);
+        partyMember.setNickname(nickname);
+        partyMemberRepo.save(partyMember);
+        
+        return "닉네임 수정 완료되었습니다.";
+    }
+
+    public void checkNickNameDuplicate(Party party, String nickname) {
+
+        List<PartyMember> partyMembers = partyMemberRepo.findByParty(party);
+        for (PartyMember member : partyMembers ) {
+            if(member.getNickname().equals(nickname)) {
+                throw new WrongInfoException("파티 내에 같은 닉네임이 있습니다." + nickname );
+            }
+        }
+
+    }
+
 }

--- a/src/main/java/kr/flab/ottsharing/service/PartyService.java
+++ b/src/main/java/kr/flab/ottsharing/service/PartyService.java
@@ -15,6 +15,7 @@ import kr.flab.ottsharing.exception.WrongInfoException;
 import kr.flab.ottsharing.protocol.MyParty;
 import kr.flab.ottsharing.protocol.PartyCreateResult;
 import kr.flab.ottsharing.protocol.PartyMemberInfo;
+import kr.flab.ottsharing.protocol.UpdatePartyInfo;
 import kr.flab.ottsharing.repository.PartyMemberRepository;
 import kr.flab.ottsharing.repository.PartyRepository;
 import kr.flab.ottsharing.repository.PartyWaitingRepository;
@@ -122,6 +123,24 @@ public class PartyService {
 
         return new MyParty(MyParty.Status.HAS_NO_PARTY);
     }
+
+    public String updatePartyInfo(UpdatePartyInfo info) {
+        User user = userRepo.findByUserId(info.getUserId()).get();
+        PartyMember partyMember = memberRepo.findOneByUser(user).get();
+        Integer partyId = partyMember.getParty().getPartyId();
+        Integer writtenPartyId = info.getPartyId();
+
+        if(!partyId.equals(writtenPartyId)) {
+            throw new WrongInfoException("해당 파티에 속하지 않았습니다. 파티id를 다시 바르게 입력해주세요"  );
+        }
+        
+        if (partymemberService.checkLeader(partyMember)) {
+            return partymemberService.changeInfoOfLeader(partyMember, partyMember.getParty(), info);
+        }
+        
+        return partymemberService.changeInfoOfMember(partyMember, partyMember.getParty(), info);
+    }
+
 
     // Party Entity 구조 변경으로 인해 동작하지 않는 코드
     public Party enrollParty(String leaderId, String getottId, String getottPassword) {


### PR DESCRIPTION
* updatePartyInfo 프로토콜을 통해 수정할 정보 얻음
* @valid를 통해 반드시 입력되어야 할 항목 검사시킴.(NotBlank)
* 리더인 경우 : 파티에서 사용될 자신의 닉네임, 파티의 ottId, 파티의 ottPassword 수정가능
* 팀원인 경우 : 파티에서 사용될 자신의 닉네임만 수정 가능 -> ottId 또는 ottPassword 수정시 예외처리
* 파티내 중복된 닉네임 있을 경우 예외처리 -> checkNickNameDuplicate
* PartyMember Entity에 @Setter 추가
* Postman으로 테스트 완료