### PR TITLE
feat : 환불 Service 구현

### DIFF
--- a/src/main/java/kr/flab/ottsharing/protocol/RefundResult.java
+++ b/src/main/java/kr/flab/ottsharing/protocol/RefundResult.java
@@ -8,7 +8,7 @@ public class RefundResult {
     private Status status;
     private Long refundMoney;
 
-    public RefundResult(Long refundMoney){
+    public RefundResult(Long refundMoney) {
         this.status = Status.SUCCESS;
         this.refundMoney = refundMoney;
     }

--- a/src/main/java/kr/flab/ottsharing/protocol/RefundResult.java
+++ b/src/main/java/kr/flab/ottsharing/protocol/RefundResult.java
@@ -1,5 +1,17 @@
 package kr.flab.ottsharing.protocol;
 
-public enum RefundResult {
-    SUCCESS
+import lombok.Getter;
+
+@Getter
+public class RefundResult {
+    
+    private Status status;
+    private Long refundMoney;
+
+    public RefundResult(Long refundMoney){
+        this.status = Status.SUCCESS;
+        this.refundMoney = refundMoney;
+    }
+
+    public enum Status { SUCCESS }
 }

--- a/src/main/java/kr/flab/ottsharing/protocol/RefundResult.java
+++ b/src/main/java/kr/flab/ottsharing/protocol/RefundResult.java
@@ -1,0 +1,5 @@
+package kr.flab.ottsharing.protocol;
+
+public enum RefundResult {
+    SUCCESS
+}

--- a/src/main/java/kr/flab/ottsharing/service/MoneyService.java
+++ b/src/main/java/kr/flab/ottsharing/service/MoneyService.java
@@ -82,7 +82,7 @@ public class MoneyService {
         Long usingMoney = 0L;
         Long refundMoney = 0L;
 
-        if(payDate == 29 || payDate == 30 || payDate == 31 ) {
+        if (payDate == 29 || payDate == 30 || payDate == 31) {
             payDate = 28;
         }
 
@@ -97,13 +97,13 @@ public class MoneyService {
             serviceFee -= 500L;
         }
 
-        if(isNowAfterPayDay) {
+        if (isNowAfterPayDay) {
             month = ChronoUnit.DAYS.between(nextMonthPay,thisMonthPay);
             usingPeriod = ChronoUnit.DAYS.between(now,thisMonthPay);
             
         }
 
-        if(!isNowAfterPayDay) {
+        if (!isNowAfterPayDay) {
             month = ChronoUnit.DAYS.between(thisMonthPay,lastMonthPay);
             usingPeriod = ChronoUnit.DAYS.between(now,lastMonthPay);
         }

--- a/src/main/java/kr/flab/ottsharing/service/MoneyService.java
+++ b/src/main/java/kr/flab/ottsharing/service/MoneyService.java
@@ -1,13 +1,19 @@
 package kr.flab.ottsharing.service;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
 import javax.transaction.Transactional;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import kr.flab.ottsharing.entity.PartyMember;
 import kr.flab.ottsharing.entity.User;
 import kr.flab.ottsharing.exception.MoneyException;
 import kr.flab.ottsharing.protocol.PayResult;
 import kr.flab.ottsharing.repository.MoneyRepository;
+import kr.flab.ottsharing.repository.PartyMemberRepository;
 import kr.flab.ottsharing.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -17,6 +23,11 @@ public class MoneyService {
     
     private final MoneyRepository moneyRepo;
     private final UserRepository userRepository;
+    private final PartyMemberService memberService;
+    private final PartyMemberRepository memberRepo;
+
+    @Value("${ottsharing.serviceFee}")
+    private Long serviceFee;
 
     public void settle(User user, int amount) {
         user.setMoney(user.getMoney() + amount);
@@ -46,7 +57,6 @@ public class MoneyService {
 
     @Transactional
     public String withdraw(String userId, int moneyToWithdraw) {
-
         User user = userRepository.findByUserId(userId).get();
         if (user.getMoney() < moneyToWithdraw) {
             throw new MoneyException("현재 돈이 부족합니다.");
@@ -55,6 +65,50 @@ public class MoneyService {
         user.setMoney(user.getMoney() - moneyToWithdraw);
         moneyRepo.save(user);
         return "출금 완료되었습니다";
+    }
+
+    @Transactional
+    public String refund(String userId) {
+        User user = userRepository.findByUserId(userId).get();
+        int payDate = user.getCreatedTime().getDayOfMonth();
+        PartyMember partymember = memberRepo.findOneByUser(user).get();
+     
+        LocalDate now = LocalDate.now();
+        int currentYear = now.getYear();
+        int currentMonth = now.getMonthValue();
+        LocalDate thisMonthPay = LocalDate.of(currentYear,currentMonth,payDate);
+        LocalDate lastMonthPay = thisMonthPay.minusMonths(1);
+        LocalDate nextMonthPay = thisMonthPay.plusMonths(1);
+
+        boolean isNowAfterPayDay = now.isAfter(thisMonthPay);
+        boolean isLeader = memberService.checkLeader(partymember);
+
+        Long usingPeriod = 0L;
+        Long month = 0L;
+        Long usingMoney = 0L;
+        Long refundMoney = 0L;
+  
+        if (isLeader) {
+            serviceFee -= 500L;
+        }
+
+        if(isNowAfterPayDay) {
+            month = ChronoUnit.DAYS.between(nextMonthPay,thisMonthPay);
+            usingPeriod = ChronoUnit.DAYS.between(now,thisMonthPay);
+            
+        }
+
+        if(!isNowAfterPayDay) {
+            month = ChronoUnit.DAYS.between(thisMonthPay,lastMonthPay);
+            usingPeriod = ChronoUnit.DAYS.between(now,lastMonthPay);
+        }
+
+        usingMoney = (serviceFee / month) * usingPeriod;
+        refundMoney = serviceFee - usingMoney;
+        user.setMoney(user.getMoney() + refundMoney);
+        moneyRepo.save(user);
+        
+        return "가상머니로 " + refundMoney +"원 환불 완료되었습니다.";
     }
 
 }

--- a/src/main/java/kr/flab/ottsharing/service/MoneyService.java
+++ b/src/main/java/kr/flab/ottsharing/service/MoneyService.java
@@ -114,7 +114,7 @@ public class MoneyService {
         user.setMoney(user.getMoney() + refundMoney);
         moneyRepo.save(user);
         
-        return RefundResult.SUCCESS;
+        return new RefundResult(refundMoney);
     }
 
 }

--- a/src/main/java/kr/flab/ottsharing/service/MoneyService.java
+++ b/src/main/java/kr/flab/ottsharing/service/MoneyService.java
@@ -12,6 +12,7 @@ import kr.flab.ottsharing.entity.PartyMember;
 import kr.flab.ottsharing.entity.User;
 import kr.flab.ottsharing.exception.MoneyException;
 import kr.flab.ottsharing.protocol.PayResult;
+import kr.flab.ottsharing.protocol.RefundResult;
 import kr.flab.ottsharing.repository.MoneyRepository;
 import kr.flab.ottsharing.repository.PartyMemberRepository;
 import kr.flab.ottsharing.repository.UserRepository;
@@ -68,7 +69,7 @@ public class MoneyService {
     }
 
     @Transactional
-    public String refund(String userId) {
+    public RefundResult refund(String userId) {
         User user = userRepository.findByUserId(userId).get();
         int payDate = user.getCreatedTime().getDayOfMonth();
         PartyMember partymember = memberRepo.findOneByUser(user).get();
@@ -86,7 +87,7 @@ public class MoneyService {
             payDate = 28;
         }
 
-        LocalDate thisMonthPay = LocalDate.of(currentYear,currentMonth,payDate);
+        LocalDate thisMonthPay = LocalDate.of(currentYear, currentMonth, payDate);
         LocalDate lastMonthPay = thisMonthPay.minusMonths(1);
         LocalDate nextMonthPay = thisMonthPay.plusMonths(1);
 
@@ -98,14 +99,14 @@ public class MoneyService {
         }
 
         if (isNowAfterPayDay) {
-            month = ChronoUnit.DAYS.between(nextMonthPay,thisMonthPay);
-            usingPeriod = ChronoUnit.DAYS.between(now,thisMonthPay);
+            month = ChronoUnit.DAYS.between(nextMonthPay, thisMonthPay);
+            usingPeriod = ChronoUnit.DAYS.between(now, thisMonthPay);
             
         }
 
         if (!isNowAfterPayDay) {
-            month = ChronoUnit.DAYS.between(thisMonthPay,lastMonthPay);
-            usingPeriod = ChronoUnit.DAYS.between(now,lastMonthPay);
+            month = ChronoUnit.DAYS.between(thisMonthPay, lastMonthPay);
+            usingPeriod = ChronoUnit.DAYS.between(now, lastMonthPay);
         }
 
         usingMoney = (serviceFee / month) * usingPeriod;
@@ -113,7 +114,7 @@ public class MoneyService {
         user.setMoney(user.getMoney() + refundMoney);
         moneyRepo.save(user);
         
-        return "가상머니로 " + refundMoney +"원 환불 완료되었습니다.";
+        return RefundResult.SUCCESS;
     }
 
 }

--- a/src/main/java/kr/flab/ottsharing/service/MoneyService.java
+++ b/src/main/java/kr/flab/ottsharing/service/MoneyService.java
@@ -76,6 +76,16 @@ public class MoneyService {
         LocalDate now = LocalDate.now();
         int currentYear = now.getYear();
         int currentMonth = now.getMonthValue();
+
+        Long usingPeriod = 0L;
+        Long month = 0L;
+        Long usingMoney = 0L;
+        Long refundMoney = 0L;
+
+        if(payDate == 29 || payDate == 30 || payDate == 31 ) {
+            payDate = 28;
+        }
+
         LocalDate thisMonthPay = LocalDate.of(currentYear,currentMonth,payDate);
         LocalDate lastMonthPay = thisMonthPay.minusMonths(1);
         LocalDate nextMonthPay = thisMonthPay.plusMonths(1);
@@ -83,11 +93,6 @@ public class MoneyService {
         boolean isNowAfterPayDay = now.isAfter(thisMonthPay);
         boolean isLeader = memberService.checkLeader(partymember);
 
-        Long usingPeriod = 0L;
-        Long month = 0L;
-        Long usingMoney = 0L;
-        Long refundMoney = 0L;
-  
         if (isLeader) {
             serviceFee -= 500L;
         }


### PR DESCRIPTION
* 파티 탈퇴 또는 파티 해체시 사용될 서비스
* 현존 앱인 pickleplus의 환불 정책을 참고함. 
 -- partyMember가 되는 createdTime의 일 날짜가 해당 사용자의 정기 지불 일 날짜임. 
 -- ex) createdTime: 2022-4-20 -> 매달 지불 일: 20일
* 지불 일이 29.30.31일 경우 28일로 지불날 변환함.(협의함)
* 월마다 한달의 기간이 다르므로 한달 기간에 대한 계산 수행함.  ex) 30,31
* ChronoUnit.DAYS.between()이 Long으로 return하는 특성으로, 관련된 것들의 타입을 Long으로 함.
 --  usingPeriod , month , usingMoney , refundMoney, serviceFee 
* 리더인지 팀원인지 구분 - 리더 총금액 4500원, 팀원 총금액 5000원
* 이번달 결제일이 이미 지나갔을때 
-- 한달 = 다음달 결제일 - 이번달 결제일
-- 사용기간 = 오늘 날짜 - 결제 날짜
* 이번달 결제일이 아직 도달 안했을때
--  한달 = 이번달 결제일 - 저번달 결제일 
-- 사용기간 = 저번달 결제날짜 - 오늘 날짜 
* 사용료 계산 = (총금액 / 한달)*사용기간
* 환불금액 = 총금액 - 사용료
* RefundResult 반환

