### PR TITLE
정산 및 자동결제 스케줄러

### DIFF
--- a/src/main/java/kr/flab/ottsharing/OttsharingApplication.java
+++ b/src/main/java/kr/flab/ottsharing/OttsharingApplication.java
@@ -2,8 +2,10 @@ package kr.flab.ottsharing;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class OttsharingApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/kr/flab/ottsharing/repository/PartyMemberRepository.java
+++ b/src/main/java/kr/flab/ottsharing/repository/PartyMemberRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import kr.flab.ottsharing.entity.Party;
@@ -19,4 +20,10 @@ public interface PartyMemberRepository extends JpaRepository<PartyMember, Intege
     void deleteAllByParty(Party party);
 
     void deleteById(Integer partyMemberId);
+
+    @Query("select pm from PartyMember pm where DAY(pm.createdTime) = ?1")
+    List<PartyMember> findByCreatedDay1To28(int day);
+    
+    @Query("select pm from PartyMember pm where DAY(pm.createdTime) >= 28 AND DAY(pm.createdTime) <= 31")
+    List<PartyMember> findByCreatedDay28To31();
 }

--- a/src/main/java/kr/flab/ottsharing/scheduler/PaySettleScheduler.java
+++ b/src/main/java/kr/flab/ottsharing/scheduler/PaySettleScheduler.java
@@ -1,0 +1,60 @@
+package kr.flab.ottsharing.scheduler;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import kr.flab.ottsharing.entity.Party;
+import kr.flab.ottsharing.entity.PartyMember;
+import kr.flab.ottsharing.entity.User;
+import kr.flab.ottsharing.protocol.PayResult;
+import kr.flab.ottsharing.service.MoneyService;
+import kr.flab.ottsharing.service.PartyMemberService;
+import kr.flab.ottsharing.service.PartyService;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PaySettleScheduler {
+    private final PartyMemberService memberService;
+    private final MoneyService moneyService;
+    private final PartyService partyService;
+
+    @Scheduled(cron = "0 0 6 * * *")
+	public void payAndSettleEverySixMorning() throws Exception {
+        List<PartyMember> members = getMembersAtPaySettleDay();
+
+        for (PartyMember member : members) {
+            boolean thisMonth = member.getCreatedTime().getMonth() == LocalDateTime.now().getMonth();
+            if (thisMonth) continue;
+            
+            User user = member.getUser();
+            Party party = member.getParty();
+
+            if (member.isLeader()) {
+                moneyService.settle(user, 15000);
+                continue;
+            }
+
+            PayResult payResult = moneyService.pay(user, 5000);
+            if (payResult == PayResult.NOT_ENOUGH_MONEY) {
+                partyService.getOutParty(user.getUserId(), party.getPartyId());
+            }
+        }
+    }
+
+    private List<PartyMember> getMembersAtPaySettleDay() {
+        int day = LocalDateTime.now().getDayOfMonth();
+        if (day > 28) {
+            return new ArrayList<>();
+        }
+
+        if (day == 28) {
+            return memberService.getUsersPaidAt(28);
+        }
+        return memberService.getUsersPaidAt(day);
+    }
+}

--- a/src/main/java/kr/flab/ottsharing/service/PartyMemberService.java
+++ b/src/main/java/kr/flab/ottsharing/service/PartyMemberService.java
@@ -115,4 +115,11 @@ public class PartyMemberService {
             }
         }
     }
+
+    public List<PartyMember> getUsersPaidAt(int day) {
+        if (day >= 28) {
+            return memberRepo.findByCreatedDay28To31();
+        }
+        return memberRepo.findByCreatedDay1To28(day);
+    }
 }


### PR DESCRIPTION
* 매일 아침 6시
* n일이 결제일/정산일인 모든 PartyMember를 찾는다 (오늘이 3월 3일이라면 n=3)
  * 28일에 28~31일의 결제/정산을 모두 처리한다
  * 29~31일에는 결제/정산을 하지 않는다
  * 관련 PartyMemberRepository 메서드 추가함
* 리더에게는 정산을, 파티원에게는 결제를 시킨다
* 파티원에게 충전된 돈이 없다면 탈퇴시킨다

closes #71 